### PR TITLE
Correct the geoid computation by constant for mass conservation

### DIFF
--- a/src/geostate.jl
+++ b/src/geostate.jl
@@ -6,7 +6,7 @@ Update the geoid by convoluting the Green's function with the load anom.
 """
 function update_geoid!(sstruct::SuperStruct{<:AbstractFloat})
     sstruct.geostate.geoid .= samesize_conv(sstruct.tools.geoidgreen,
-        totalmass_anom(sstruct), sstruct.Omega)
+        mass_anom(sstruct), sstruct.Omega, no_mean_bc)
     return nothing
 end
 
@@ -77,13 +77,9 @@ function columnanom_full(sstruct::SuperStruct{<:AbstractFloat})
         columnanom_litho(sstruct)
 end
 
-function loadanom_elasticgreen(sstruct::SuperStruct{<:AbstractFloat})
-    return correct_surfacedisctortion(columnanom_load(sstruct), sstruct)
-end
-
-function overburdenmass_anom(sstruct::SuperStruct{<:AbstractFloat})
+function mass_anom(sstruct::SuperStruct{<:AbstractFloat})
     surface = (sstruct.Omega.dx * sstruct.Omega.dy)
-    return correct_surfacedisctortion(surface .* columnanom_load(sstruct), sstruct)
+    return correct_surfacedisctortion(surface .* columnanom_full(sstruct), sstruct)
 end
 
 function correct_surfacedisctortion(column::Matrix, sstruct::SuperStruct)

--- a/src/mechanics.jl
+++ b/src/mechanics.jl
@@ -134,6 +134,7 @@ function forwardstep_isostasy!(
     t::T,
 ) where {T<:AbstractFloat}
 
+    # Order really matters here!
     sstruct.Omega.bc!(u, sstruct.Omega.Nx, sstruct.Omega.Ny)
     update_bedrock!(sstruct, u)
 

--- a/src/mechanics.jl
+++ b/src/mechanics.jl
@@ -138,6 +138,8 @@ function forwardstep_isostasy!(
     update_bedrock!(sstruct, u)
 
     update_loadcolumns!(sstruct, sstruct.Hice(t))
+    update_elasticresponse!(sstruct)
+
     # Only update the geoid and sea level if geostate is interactive.
     # As integration requires smaller time steps than diagnostics,
     # only update geostate every sstruct.geostate.dt
@@ -149,7 +151,6 @@ function forwardstep_isostasy!(
         # println("Updated GeoState at t=$(seconds2years(t))")
     end
 
-    update_elasticresponse!(sstruct)
     dudt_isostasy!(dudt, u, sstruct, t)
     return nothing
 end

--- a/src/mechanics.jl
+++ b/src/mechanics.jl
@@ -134,11 +134,7 @@ function forwardstep_isostasy!(
     t::T,
 ) where {T<:AbstractFloat}
 
-    if sstruct.Omega.BC == "zero_meancorner"
-        corner_bc!(u, sstruct.Omega.Nx, sstruct.Omega.Ny)
-    elseif sstruct.Omega.BC == "zero_meanedge"
-        edge_bc!(u, sstruct.Omega.Nx, sstruct.Omega.Ny)
-    end
+    sstruct.Omega.bc!(u, sstruct.Omega.Nx, sstruct.Omega.Ny)
     update_bedrock!(sstruct, u)
 
     update_loadcolumns!(sstruct, sstruct.Hice(t))
@@ -229,6 +225,7 @@ function corner_bc!(u::AbstractMatrix{<:AbstractFloat}, Nx::Int, Ny::Int)
     allowscalar() do
         u .-= ( view(u,1,1) + view(u,1,Nx) + view(u,Ny,1) + view(u,Ny,Nx) ) / 4
     end
+    return u
 end
 
 """
@@ -249,35 +246,35 @@ function edge_bc!(u::AbstractMatrix{<:AbstractFloat}, Nx::Int, Ny::Int)
         u .-= sum( view(u,1,:) + view(u,:,Nx) + view(u,Ny,:) + view(u,:,1) ) /
             (2*Nx + 2*Ny)
     end
+    return u
+end
+
+no_bc!(u::AbstractMatrix{<:AbstractFloat}, Nx::Int, Ny::Int) = nothing
+no_bc(u::AbstractMatrix{<:AbstractFloat}, Nx::Int, Ny::Int) = u
+
+function no_mean_bc!(u::AbstractMatrix{<:AbstractFloat}, Nx::Int, Ny::Int)
+    u .= u .- mean(u)
+    return u
+end
+
+function no_mean_bc(u::AbstractMatrix{<:AbstractFloat}, Nx::Int, Ny::Int)
+    u_bc = copy(u)
+    return no_mean_bc!(u_bc, Nx, Ny)
 end
 
 #####################################################
 # Elastic response
 #####################################################
-# """
-
-#     compute_elastic_response(Omega, tools, load)
-
-# For a computation domain `Omega`, compute the elastic response of the solid Earth
-# by convoluting the `load` with the Green's function stored in the pre-computed `tools`
-# (elements obtained from Farell 1972).
-# """
-# function compute_elastic_response(
-#     Omega::ComputationDomain{T},
-#     tools::PrecomputedFastiso{T},
-#     load::AbstractMatrix{T},
-# ) where {T<:AbstractFloat}
-#     return samesize_conv(load, tools.elasticgreen, Omega)
-# end
-
 """
 
     update_elasticresponse!(sstruct::SuperStruct)
 
 Update the elastic response by convoluting the Green's function with the load anom.
+To use coefficients differing from (Farell 1972), see [PrecomputedFastiso](@ref).
 """
 function update_elasticresponse!(sstruct::SuperStruct{<:AbstractFloat})
+    rgh = correct_surfacedisctortion(columnanom_load(sstruct), sstruct)
     sstruct.geostate.ue .= samesize_conv(sstruct.tools.elasticgreen,
-        loadanom_elasticgreen(sstruct), sstruct.Omega)
+        rgh, sstruct.Omega, no_bc)
     return nothing
 end

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -57,7 +57,7 @@ struct ComputationDomain{T<:AbstractFloat}
     biharmonic::AbstractMatrix{T}   # biharmonic operator
     use_cuda::Bool
     arraykernel                     # Array or CuArray depending on chosen hardware
-    BC::String                      # Boundary conditions
+    bc!::Function                   # Boundary conditions
     extension::Function             # Function to extend domain if needed for BCs
     fdxx::Function                  # FDM for 2nd order derivative in x
     fdyy::Function                  # FDM for 2nd order derivative in y
@@ -75,7 +75,7 @@ function ComputationDomain(
     Wy::T,
     Nx::Int,
     Ny::Int;
-    BC::String = "corner_bc",
+    bc!::Function = corner_bc!,
     use_cuda::Bool = false,
     lat0::T = T(-71.0),
     lon0::T = T(0.0),
@@ -118,7 +118,7 @@ function ComputationDomain(
     return ComputationDomain(Wx, Wy, Nx, Ny, Mx, My, dx, dy, x, y, X, Y,
         R, Theta, Lat, Lon, K, projection_correction, null,
         pseudodiff, harmonic, biharmonic, use_cuda, arraykernel,
-        BC, extension, fdxx, fdyy, fdxy)
+        bc!, extension, fdxx, fdyy, fdxy)
 end
 
 #########################################################

--- a/test/Manifest.toml
+++ b/test/Manifest.toml
@@ -1,8 +1,8 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.9.0"
+julia_version = "1.9.2"
 manifest_format = "2.0"
-project_hash = "560721a11399ae386f717e1d89771021b3e3cb56"
+project_hash = "edf95e9dee1ccde31dd6f5a7a655494cd6df2585"
 
 [[deps.AbstractFFTs]]
 deps = ["LinearAlgebra"]
@@ -150,7 +150,7 @@ weakdeps = ["Dates", "LinearAlgebra"]
 [[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
-version = "1.0.2+0"
+version = "1.0.5+0"
 
 [[deps.ConstructionBase]]
 deps = ["LinearAlgebra"]
@@ -260,9 +260,9 @@ version = "4.4.2+2"
 
 [[deps.FFTW]]
 deps = ["AbstractFFTs", "FFTW_jll", "LinearAlgebra", "MKL_jll", "Preferences", "Reexport"]
-git-tree-sha1 = "f9818144ce7c8c41edf5c4c179c684d92aa4d9fe"
+git-tree-sha1 = "b4fbdd20c889804969571cc589900803edda16b7"
 uuid = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
-version = "1.6.0"
+version = "1.7.1"
 
 [[deps.FFTW_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -830,7 +830,7 @@ version = "0.40.1+0"
 [[deps.Pkg]]
 deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-version = "1.9.0"
+version = "1.9.2"
 
 [[deps.PkgVersion]]
 deps = ["Pkg"]
@@ -1263,7 +1263,7 @@ version = "0.15.1+0"
 [[deps.libblastrampoline_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
-version = "5.7.0+0"
+version = "5.8.0+0"
 
 [[deps.libfdk_aac_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]

--- a/test/Manifest.toml
+++ b/test/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.9.2"
 manifest_format = "2.0"
-project_hash = "edf95e9dee1ccde31dd6f5a7a655494cd6df2585"
+project_hash = "560721a11399ae386f717e1d89771021b3e3cb56"
 
 [[deps.AbstractFFTs]]
 deps = ["LinearAlgebra"]

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,7 +1,6 @@
 [deps]
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
-FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"

--- a/test/test2_compute.jl
+++ b/test/test2_compute.jl
@@ -45,7 +45,7 @@ function main(
     sl0 = fill(-Inf, Omega.Nx, Omega.Ny)
     t1 = time()
     results = fastisostasy(t_out, Omega, c, p, H_ice, sealevel_0 = sl0,
-        ODEsolver = BS3(), interactive_geostate = true)
+        ODEsolver = "ExplicitEuler", interactive_geostate = true)
     t_fastiso = time() - t1
     println("Took $t_fastiso seconds!")
     println("-------------------------------------")

--- a/test/test2_compute.jl
+++ b/test/test2_compute.jl
@@ -14,7 +14,7 @@ function main(
     Omega = ComputationDomain(W, n, use_cuda = use_cuda)
     c = PhysicalConstants(rho_ice = 0.931e3)
     G = 0.50605e11              # shear modulus (Pa)
-    nu = 0.5
+    nu = 0.28
     E = G * 2 * (1 + nu)
     lb = c.r_equator .- [6301e3, 5951e3, 5701e3]
     p = MultilayerEarth(
@@ -44,7 +44,8 @@ function main(
 
     sl0 = fill(-Inf, Omega.Nx, Omega.Ny)
     t1 = time()
-    results = fastisostasy(t_out, Omega, c, p, H_ice, sealevel_0=sl0, interactive_geostate=true)
+    results = fastisostasy(t_out, Omega, c, p, H_ice, sealevel_0 = sl0,
+        ODEsolver = BS3(), interactive_geostate = true)
     t_fastiso = time() - t1
     println("Took $t_fastiso seconds!")
     println("-------------------------------------")

--- a/test/test2_plot.jl
+++ b/test/test2_plot.jl
@@ -28,11 +28,19 @@ function slice_spada(
     labels,
     xlabels,
     ylabels,
+    case,
 ) where {T<:AbstractFloat}
 
     ncases = length(vars)
     data = get_spada()
     keys = ["u_disc", "u_cap", "dudt_disc", "dudt_cap", "n_disc", "n_cap"]
+
+    if case == "viscous"
+        for k in eachindex(data["u_disc"])
+            data["u_disc"][k][:, 2] .-= data["u_disc"][1][:, 2]
+            data["u_cap"][k][:, 2] .-= data["u_cap"][1][:, 2]
+        end
+    end
 
     fig = Figure(resolution=(1600, 1200), fontsize = 35)
     nrows, ncols = 3, 2
@@ -173,6 +181,7 @@ function main(
         res_disc.t_out, t_plot,
         plotvars,
         labels, xlabels, ylabels,
+        case,
     )
     plotname = "test2/$(case)_$suffix"
     save("plots/$plotname.png", response_fig)

--- a/test/test2_plot.jl
+++ b/test/test2_plot.jl
@@ -114,7 +114,7 @@ function main(
 )
 
     N = 2^n
-    suffix = "N$(N)_$(kernel)"
+    suffix = "Nx$(N)_Ny$(N)_$(kernel)"
     sol_disc = load("data/test2/disc_$suffix.jld2")
     sol_cap = load("data/test2/cap_$suffix.jld2")
     res_disc = sol_disc["results"]
@@ -180,7 +180,7 @@ function main(
 end
 
 cases = ["viscoelastic", "viscous"]
-for case in cases[2:2]
+for case in cases
     for n in 6:6
         main(case, n, kernel = "cpu")
     end

--- a/test/test3_compare3DGIA.jl
+++ b/test/test3_compare3DGIA.jl
@@ -4,7 +4,7 @@ using CairoMakie
 using JLD2, DelimitedFiles
 include("helpers_plot.jl")
 
-n = 7
+n = 6
 heterogeneous = "none"
 global include_elastic = true
 

--- a/test/test3_compute.jl
+++ b/test/test3_compute.jl
@@ -34,8 +34,8 @@ function main(
     t1 = time()
     results = fastisostasy(
         t_out, Omega, c, p, Hcylinder,
-        interactive_geostate = false, dt = years2seconds(2.0),
-        ODEsolver = "ExplicitEuler")
+        interactive_geostate = false, # dt = years2seconds(2.0),
+        ODEsolver = BS3())
     t_fastiso = time() - t1
     println("Took $t_fastiso seconds!")
     println("-------------------------------------")
@@ -54,7 +54,7 @@ function main(
     )
 end
 
-for n in 7:7
+for n in 6:6
     # ["gaussian_lo_D", "gaussian_hi_D", "no_litho", "ref", "gaussian_lo_η", "gaussian_hi_η"]
     for case in ["ref"]
         main(n, case, use_cuda = false, dense_out = true)


### PR DESCRIPTION
Geoid is required to have zero mean over extended domain. Now matches the geoid of benchmark (Spada et al. 2011) well.