### PR TITLE
Simplify the computation of the Green's function for ELRA displacement

### DIFF
--- a/src/FastIsostasy.jl
+++ b/src/FastIsostasy.jl
@@ -14,7 +14,7 @@ using OrdinaryDiffEqTsit5: init, ODEProblem, solve, DiscreteCallback, CallbackSe
 
 using ParallelStencil: ParallelStencil, @init_parallel_stencil, @parallel, @parallel_indices
 using Statistics: mean, cov, std
-using SpecialFunctions: besselj0, besselj1
+using SpecialFunctions: besselj0, besselj1, besselk
 
 # Init stencil on GPU. Will only be used if specified in RegionalDomain.
 allowscalar(false)
@@ -131,7 +131,7 @@ export AbstractCompressibility, IncompressibleMantle, CompressibleMantle, apply_
 
 export AbstractViscosityLumping, TimeDomainViscosityLumping
 export FreqDomainViscosityLumping, MeanViscosityLumping, MeanLogViscosityLumping
-export get_effective_viscosity_and_scaling
+export get_effective_viscosity_and_scaling, green_viscous
 
 export get_relaxation_time, get_relaxation_time_weaker, get_relaxation_time_stronger
 export get_rigidity, get_shearmodulus, get_elastic_green, get_flexural_lengthscale

--- a/src/deformation.jl
+++ b/src/deformation.jl
@@ -116,7 +116,8 @@ function update_deformation_rhs!(sim::Simulation, u)
         muladd(sim.solidearth.litho_poissonratio, P.buffer_yy, P.buffer_xx)
     @. P.Myy = -sim.solidearth.litho_rigidity *
         muladd(sim.solidearth.litho_poissonratio, P.buffer_xx, P.buffer_yy)
-    @. P.Mxy = -sim.solidearth.litho_rigidity * (1 - sim.solidearth.litho_poissonratio) * P.buffer_xy
+    @. P.Mxy = -sim.solidearth.litho_rigidity *
+        (1 - sim.solidearth.litho_poissonratio) * P.buffer_xy
     update_second_derivatives!(P.buffer_xx, P.buffer_yy, P.buffer_x, P.buffer_xy,
         P.Mxx, P.Myy, P.Mxy, domain)
     @. P.rhs += P.buffer_xx + muladd(2, P.buffer_xy, P.buffer_yy)

--- a/src/domain.jl
+++ b/src/domain.jl
@@ -166,3 +166,5 @@ function RegionalDomain(
         R, Theta, Lat, Lon, K, K .* dx, K .* dy, (dx * dy) .* K .^ 2, correct_distortion,
         zeros, pseudodiff, use_cuda, arraykernel)
 end
+
+Base.eltype(domain::RegionalDomain) = eltype(domain.x)

--- a/src/io.jl
+++ b/src/io.jl
@@ -176,6 +176,13 @@ io_dict[:pseudodiff_scaling] = Dict(
     "dims" => "x y",
     "map" => x -> x,
 )
+io_dict[:maskactive] = Dict(
+    "shortname" => "active_mask",
+    "longname" => "Mask where load is active",
+    "units" => "1",
+    "dims" => "x y",
+    "map" => x -> x,
+)
 """
 $(TYPEDSIGNATURES)
 

--- a/src/material.jl
+++ b/src/material.jl
@@ -167,6 +167,7 @@ function get_effective_viscosity_and_scaling(domain, layer_viscosities, layer_bo
                 layer_boundaries[:, :, end - l]
             viscosity_ratio .= layer_viscosities[:, :, end - l] ./ effective_viscosity
             R .*= channel_scaling_freqdomain_2D(domain, viscosity_ratio, channel_thickness, maskactive)
+            @show extrema(R)
             if maximum(R) == typemax(eltype(R))
                 error("The scaling factor R is too large. Try to introduce intermediate layers if you do not want to change the floating point precision.")
             end
@@ -229,21 +230,35 @@ function channel_scaling_freqdomain_0D(
 end
 
 function channel_scaling(domain, kappa, channel_thickness, visc_ratio)
-    C = cosh.(channel_thickness .* kappa)
-    S = sinh.(channel_thickness .* kappa)
-    
-    num = zeros(domain)
-    denum = zeros(domain)
+    Text = eltype(domain)
+    Tint = Float64
+
+    @show extrema(visc_ratio)
+    @show extrema(channel_thickness)
+
+    C = Tint.(cosh.(channel_thickness .* kappa))
+    @show extrema(C)
+    S = Tint.(sinh.(channel_thickness .* kappa))
+    @show extrema(S)
+
+    num = zeros(Tint, domain.nx, domain.ny)
+    denum = copy(num)
 
     @. num += 2 * visc_ratio * C * S
+    @show extrema(num)
     @. num += (1 - visc_ratio ^ 2) * channel_thickness ^ 2 * kappa ^ 2
+    @show extrema(num)
     @. num += visc_ratio ^ 2 * S ^ 2 + C ^ 2
+    @show extrema(num)
 
     @. denum += (visc_ratio + 1 / visc_ratio) * C * S
+    @show extrema(denum)
     @. denum += (visc_ratio - 1 / visc_ratio) * channel_thickness * kappa
+    @show extrema(denum)
     @. denum += S ^ 2 + C ^ 2
+    @show extrema(denum)
     
-    return num ./ denum
+    return Text.(num ./ denum)
 end
 
 function channel_scaling_freqdomain_2D(
@@ -352,86 +367,16 @@ end
 # RelaxedMantle properties
 ######################################################################################
 
-"""
-$(TYPEDSIGNATURES)
-
-Calculate the Kelvin filter in 2D.
-
-# Arguments
-- `filt::Matrix`: The filter array to be filled with Kelvin function values.
-- `L_w::Real`: The characteristic length scale.
-- `dx::Real`: The grid spacing in the x-direction.
-- `dy::Real`: The grid spacing in the y-direction.
-
-# Returns
-- `filt::Matrix{T}`: The filter array filled with Kelvin function values.
-"""
-function get_kei(domain::RegionalDomain{T, <:Any, <:Any}, L_w) where
-    {T<:AbstractFloat}
-
-    (;nx, ny, dx, dy) = domain
-    if nx != ny
-        error("The Kelvin filter is only implemented for square domains.")
-    end
-    n2 = (nx-1) ÷ 2
-
-    # Load tabulated values and init filt before filling with loop
-    rn_vals, kei_vals = load_viscous_kelvin_function(T)
-    filt = zeros(domain)
-    for j = -n2:n2
-        for i = -n2:n2
-            x = i*dx
-            y = j*dy
-            r = sqrt(x^2 + y^2)
-
-            # Get actual index of array
-            i1 = i + 1 + n2
-            j1 = j + 1 + n2
-
-            # Get correct kei value for this point
-            filt[i1, j1] = get_kei_value(r, L_w, rn_vals, kei_vals)
-        end
-    end
-
-    return filt
+function besselkei(x)
+    z = x * exp(im * pi / 4)
+    return imag(besselk(0, z))
 end
 
-"""
-$(TYPEDSIGNATURES)
-
-Calculate the Kelvin function (kei) value based on the radius from the point load `r`,
-the flexural length scale `L_w`, and the arrays of normalized radii `rn_vals` and
-corresponding kei values `kei_vals`.
-
-This function first normalizes the radius `r` by the flexural length scale `L_w` to get
-the current normalized radius. If this value is greater than the maximum value in `rn_vals`,
-the function returns the maximum value in `kei_vals`. Otherwise, it finds the interval in
-`rn_vals` that contains the current normalized radius and performs a linear interpolation
-to calculate the corresponding kei value.
-"""
-function get_kei_value(r, L_w, rn_vals, kei_vals)
-    n = length(rn_vals)
-
-    # Get current normalized radius from point load
-    rn_now = r / L_w
-
-    if rn_now > rn_vals[n]
-        kei = kei_vals[n]
-    else
-        k = 1
-        while k < n
-            if rn_now >= rn_vals[k] && rn_now < rn_vals[k+1]
-                break
-            end
-            k += 1
-        end
-
-        # Linear interpolation to get current kei value
-        kei = kei_vals[k] + (rn_now - rn_vals[k]) / (rn_vals[k+1] - rn_vals[k]) *
-            (kei_vals[k+1] - kei_vals[k])
-    end
-
-    return kei
+function green_viscous(domain, rho, D)
+    L = get_flexural_lengthscale(D, rho, 9.81)
+    R = max.(domain.R, 1)
+    return map(r -> -(L^2 / (2 * pi * D) * besselkei(r / L)), R) .*
+        (domain.dx * domain.dy)
 end
 
 """
@@ -451,17 +396,6 @@ The flexural length scale will be on the order of 100km.
 function get_flexural_lengthscale(litho_rigidity, rho_uppermantle, g)
     L_w = (litho_rigidity / (rho_uppermantle*g)) .^ 0.25
     return L_w
-end
-
-"""
-$(TYPEDSIGNATURES)
-
-Calculate the viscous Green's function. Note that L_w contains information about
-the density of the upper mantle.
-
-"""
-function calc_viscous_green(domain, litho_rigidity, kei, L_w)
-    return -L_w^2 ./ (2*pi*litho_rigidity) .* kei .* (domain.dx*domain.dy)
 end
 
 """

--- a/src/solidearth.jl
+++ b/src/solidearth.jl
@@ -136,6 +136,7 @@ mutable struct SolidEarth{
     litho_poissonratio::T
     mantle_poissonratio::T
     tau::M
+    scale_elralength::T
     litho_youngmodulus::T
     litho_shearmodulus::T
     rho_uppermantle::T
@@ -156,6 +157,7 @@ function SolidEarth(
     litho_poissonratio = T(DEFAULT_LITHO_POISSONRATIO),
     mantle_poissonratio = T(DEFAULT_MANTLE_POISSONRATIO),
     tau = T(DEFAULT_MANTLE_TAU),
+    scale_elralength = T(1),                        # Following LeMeur (1996, text below Eq. 3)
     rho_uppermantle = T(DEFAULT_RHO_UPPERMANTLE),   # Mean density of topmost upper mantle (kg m^-3)
     rho_litho = T(DEFAULT_RHO_LITHO),               # Mean density of lithosphere (kg m^-3)
 ) where {T<:AbstractFloat, L, M}
@@ -195,7 +197,7 @@ function SolidEarth(
         lithosphere, mantle, calibration, compressibility, lumping,
         effective_viscosity, pseudodiff_scaling, scaled_pseudodiff_inv,
         litho_thickness, litho_rigidity, kernelcollect(maskactive, domain),
-        litho_poissonratio, mantle_poissonratio, tau,
+        litho_poissonratio, mantle_poissonratio, tau, scale_elralength,
         litho_youngmodulus, litho_shearmodulus, rho_uppermantle, rho_litho,
     )
 

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -47,19 +47,17 @@ struct GIATools{
 end
 
 function GIATools(domain, c, solidearth;
-    quad_precision::Int = 4, rhs_smooth_radius = nothing)
+    quad_precision::Int = 4,
+    rhs_smooth_radius = nothing)
 
     T = eltype(domain.R)
 
-    # Build in-place convolution for viscous response (only used in ELRA)
-    L_w = get_flexural_lengthscale(
-        mean(solidearth.litho_rigidity),
-        solidearth.rho_uppermantle,
-        c.g,
-    )
-    kei = get_kei(domain, L_w)
     viscous_green = domain.arraykernel(T.(
-        calc_viscous_green(domain, mean(solidearth.litho_rigidity), kei, L_w)))
+        green_viscous(
+            domain,
+            solidearth.rho_uppermantle,
+            mean(solidearth.litho_rigidity),
+        )))
     conv_helpers = ConvolutionPlanHelpers(viscous_green)
     viscous_convo = ConvolutionPlan(viscous_green, conv_helpers)
 
@@ -95,7 +93,7 @@ function GIATools(domain, c, solidearth;
     cplxmatrices = [complex.(kernelzeros(domain)) for _ in 1:n_cplx_matrices]
     prealloc = PreAllocated(realmatrices..., cplxmatrices...)
     return GIATools(conv_helpers, viscous_convo, elastic_convo, dz_ss_convo,
-        smooth_convo, pfft!, pifft!, prealloc)
+        smooth_convo, pfft!, pifft!, prealloc), viscous_green
 end
 
 


### PR DESCRIPTION
Previously, we were relying on tabulated values to compute `kei`. However, this can be computed directly within FastIsostasy thanks to the use of Bessel functions. Comparing the old method and the new method (same color range) gives:

<img width="1088" height="527" alt="Screenshot From 2025-08-01 11-06-32" src="https://github.com/user-attachments/assets/b9f50907-7c4a-4baa-9fc3-4795114044cd" />

Which is essentially the same but more accurate (because no interpolation) and does not need do download anything (nice to work offline).